### PR TITLE
Support out of region access

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,10 +3,11 @@ name: h5coro
 channels:
   - conda-forge
 dependencies:
+  - python>=3.7
+  - pip
   - pytest
   - numpy
   - boto3
   - s3fs
   - h5py
   - sliderule
-  - earthaccess>=0.5.3

--- a/environment.yml
+++ b/environment.yml
@@ -3,11 +3,10 @@ name: h5coro
 channels:
   - conda-forge
 dependencies:
-  - python
-  - pip
   - pytest
   - numpy
   - boto3
   - s3fs
   - h5py
   - sliderule
+  - earthaccess>=0.5.3

--- a/h5coro/h5coro.py
+++ b/h5coro/h5coro.py
@@ -78,10 +78,10 @@ class H5Coro:
     #######################
     # Constructor
     #######################
-    def __init__(self, 
-        resource, 
-        driver_class, 
-        credentials={}, 
+    def __init__(self,
+        resource,
+        driver_class,
+        credentials={},
         cacheLineSize = CACHE_LINE_SIZE_DEFAULT,
         enablePrefetch = ENABLE_PREFETCH_DEFAULT,
         errorChecking = ERROR_CHECKING_DEFAULT,
@@ -161,14 +161,14 @@ class H5Coro:
 
             # read elements in group
             H5Dataset(self, group, earlyExit=False, metaOnly=True, enableAttributes=w_attr)
-    
+
             # massage group name to remove leading and trailing slashes
             if group[0] == '/':
                 group = group[1:]
             if group[-1] == '/':
                 group = group[:-1]
 
-            # populate variables and attributes by filtering metadataTable 
+            # populate variables and attributes by filtering metadataTable
             # for all entries starting with group string
             paths = self.metadataTable.keys()
             for path in paths:

--- a/h5coro/h5dataset.py
+++ b/h5coro/h5dataset.py
@@ -127,7 +127,7 @@ class H5Dataset:
         self.dataChunkBufferSize    = 0
         self.meta                   = H5Metadata()
         self.values                 = None
-        
+
         # check for null dataset
         # (to handle datasets that error out and cannot be read)
         if makeNull:
@@ -339,7 +339,7 @@ class H5Dataset:
     #######################
     # readSuperblock
     #
-    #   Note: this is NOT a class method as it takes a 'resourceObject' 
+    #   Note: this is NOT a class method as it takes a 'resourceObject'
     #   and populates critical attributes of that object; this should
     #   be called in h5coro and passed the self member
     #######################

--- a/h5coro/webdriver.py
+++ b/h5coro/webdriver.py
@@ -1,0 +1,45 @@
+import requests
+import logging
+
+###############################################################################
+# Globals
+###############################################################################
+
+logger = logging.getLogger(__name__)
+
+###############################################################################
+# Exceptions
+###############################################################################
+
+class FatalError(RuntimeError):
+    pass
+
+###############################################################################
+# S3Driver Class
+###############################################################################
+
+class HTTPDriver:
+
+    #######################
+    # Constructor
+    #######################
+    def __init__(self, resource, credentials):
+
+        # construct path to resource
+        self.resource = resource
+        if type(credentials) is str:
+            self.session = requests.Session(headers={"Authorization": f"Bearer: {credentials}"})
+        else:
+            self.session = requests.Session()
+
+    #######################
+    # read
+    #######################
+    def read(self, pos, size):
+        headers = {"Range": f"bytes={pos}-{pos+size-1}"}
+        stream = self.session.get(self.resource, headers=headers, allow_redirects=True)
+        if stream.status_code > 200 and stream.status_code < 400:
+            return stream.content
+        else:
+            raise FatalError
+

--- a/h5coro/webdriver.py
+++ b/h5coro/webdriver.py
@@ -24,7 +24,14 @@ class HTTPDriver:
     # Constructor
     #######################
     def __init__(self, resource, credentials):
+        """HTTP driver for H5Coro
 
+        Parameters:
+            resource (String): HTTP URL pointing to a NASA file
+            credentials (String): EDL token
+        Returns:
+            class HTTPDriver: reader that can access NASA data out of us-west-2
+        """
         # construct path to resource
         self.resource = resource
         self.session = requests.Session()

--- a/h5coro/webdriver.py
+++ b/h5coro/webdriver.py
@@ -27,10 +27,10 @@ class HTTPDriver:
 
         # construct path to resource
         self.resource = resource
+        self.session = requests.Session()
         if type(credentials) is str:
-            self.session = requests.Session(headers={"Authorization": f"Bearer: {credentials}"})
-        else:
-            self.session = requests.Session()
+            self.token = credentials
+            self.session.headers.update({"Authorization": f"Bearer {self.token}"})
 
     #######################
     # read
@@ -41,5 +41,6 @@ class HTTPDriver:
         if stream.status_code > 200 and stream.status_code < 400:
             return stream.content
         else:
+            print(stream, stream.request.headers)
             raise FatalError
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 numpy
 boto3
+requests

--- a/tests/test_icesat2.py
+++ b/tests/test_icesat2.py
@@ -2,13 +2,28 @@
 
 import pytest
 import h5coro
-from h5coro import filedriver, s3driver
+import os
+
+
+from h5coro import filedriver, s3driver, webdriver
 
 ATL03_S3_OBJECT = "sliderule/data/ATLAS/ATL03_20181017222812_02950102_005_01.h5"
 ATL03_FILE = "/data/ATLAS/ATL03_20181017222812_02950102_005_01.h5"
+ATL03_HTTP_URL = "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-protected/ATLAS/ATL06/006/2018/10/14/ATL06_20181014001049_02350102_006_02.h5"
+
+
 
 @pytest.mark.region
 class TestIcesat2:
+
+    def test_http_driver(self):
+        edl_token = os.environ.get("EDL_TOKEN")
+
+        h5obj = h5coro.H5Coro(ATL03_HTTP_URL, webdriver.HTTPDriver, credentials=edl_token)
+        promise = h5obj.readDatasets(['/gt1r/land_ice_segments/h_li'], block=True)
+        assert promise['/gt1r/land_ice_segments/h_li'].elements > 0
+        assert promise['/gt1r/land_ice_segments/h_li'].numcols == 1
+
     def test_s3driver(self):
         h5obj = h5coro.H5Coro(ATL03_S3_OBJECT, s3driver.S3Driver)
         promise = h5obj.readDatasets(['/gt2l/heights/h_ph'])


### PR DESCRIPTION
This PR adds a webdriver so `h5coro` can access data when we are not in `us-west-2`, the auth mechanism work with EDL token, see unit test. 

```python
edl_token = os.environ.get("EDL_TOKEN")
h5obj = h5coro.H5Coro(ATL03_HTTP_URL, webdriver.HTTPDriver, credentials=edl_token)
promise = h5obj.readDatasets(['/gt1r/land_ice_segments/h_li'], block=True)
```

With this change we can access data from other DAACs as well.