### PR TITLE
fix: replace `pkg_resources` to prevent deprecation warning

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/h5coro/version.py
+++ b/h5coro/version.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python
 u"""
-version.py (04/2021)
-Gets semantic version number and commit hash from setuptools-scm
+version.py (11/2023)
+Gets version number of a package
 """
-from pkg_resources import get_distribution
+import importlib.metadata
 
-# get semantic version from setuptools-scm
-version = get_distribution("h5coro").version
+# package metadata
+metadata = importlib.metadata.metadata("h5coro")
+# get version
+version = metadata["version"]
 # append "v" before the version
 full_version = "v{0}".format(version)
+# get project name
+project_name = metadata["Name"]


### PR DESCRIPTION
ci: bump versions to fix deprecation warnings
