### PR TITLE
Adding access to public S3 buckets

### DIFF
--- a/h5coro/s3driver.py
+++ b/h5coro/s3driver.py
@@ -1,5 +1,7 @@
-import boto3
 import logging
+
+import boto3
+from botocore.handlers import disable_signing
 
 ###############################################################################
 # Globals
@@ -11,50 +13,67 @@ logger = logging.getLogger(__name__)
 # Exceptions
 ###############################################################################
 
+
 class FatalError(RuntimeError):
     pass
+
 
 ###############################################################################
 # S3Driver Class
 ###############################################################################
 
-class S3Driver:
 
+class S3Driver:
     #######################
     # Constructor
     #######################
     def __init__(self, resource, credentials):
-
         # construct path to resource
-        self.resourcePath = list(filter(('').__ne__, resource.split('/')))
+        self.resourcePath = list(filter(("").__ne__, resource.split("/")))
 
-        # apply credentials if supplied
-        if "profile" in credentials:
-            self.session = boto3.Session(profile_name=credentials["profile"])
-        elif "aws_access_key_id" in credentials and \
-             "aws_secret_access_key" in credentials and \
-             "aws_session_token" in credentials:
-            self.session = boto3.Session(aws_access_key_id=credentials["aws_access_key_id"],
-                                         aws_secret_access_key=credentials["aws_secret_access_key"],
-                                         aws_session_token=credentials["aws_session_token"])
-        elif "accessKeyId" in credentials and \
-             "secretAccessKey" in credentials and \
-             "sessionToken" in credentials:
-            self.session = boto3.Session(aws_access_key_id=credentials["accessKeyId"],
-                                         aws_secret_access_key=credentials["secretAccessKey"],
-                                         aws_session_token=credentials["sessionToken"])
-        elif len(credentials) == 0:
+        if "annon" in credentials and credentials["annon"]:
             self.session = boto3.Session()
+            # Register the event handler to disable signing
+            self.session.events.register("choose-signer.s3.*", disable_signing)
         else:
-            raise FatalError('invalid credential keys provided, looking for: aws_access_key_id, aws_secret_access_key, and aws_session_token')
+            # apply credentials if supplied
+            if "profile" in credentials:
+                self.session = boto3.Session(profile_name=credentials["profile"])
+            elif (
+                "aws_access_key_id" in credentials
+                and "aws_secret_access_key" in credentials
+                and "aws_session_token" in credentials
+            ):
+                self.session = boto3.Session(
+                    aws_access_key_id=credentials["aws_access_key_id"],
+                    aws_secret_access_key=credentials["aws_secret_access_key"],
+                    aws_session_token=credentials["aws_session_token"],
+                )
+            elif (
+                "accessKeyId" in credentials
+                and "secretAccessKey" in credentials
+                and "sessionToken" in credentials
+            ):
+                self.session = boto3.Session(
+                    aws_access_key_id=credentials["accessKeyId"],
+                    aws_secret_access_key=credentials["secretAccessKey"],
+                    aws_session_token=credentials["sessionToken"],
+                )
+            elif len(credentials) == 0:
+                self.session = boto3.Session()
+            else:
+                raise FatalError(
+                    "invalid credential keys provided, looking for: aws_access_key_id, aws_secret_access_key, and aws_session_token"
+                )
 
         # open resource
-        self.obj = self.session.resource('s3').Object(self.resourcePath[0], '/'.join(self.resourcePath[1:]))
+        self.obj = self.session.resource("s3").Object(
+            self.resourcePath[0], "/".join(self.resourcePath[1:])
+        )
 
     #######################
     # read
     #######################
     def read(self, pos, size):
-        stream = self.obj.get(Range=f'bytes={pos}-{pos+size-1}')['Body']
+        stream = self.obj.get(Range=f"bytes={pos}-{pos+size-1}")["Body"]
         return stream.read()
-

--- a/tests/test_icesat2.py
+++ b/tests/test_icesat2.py
@@ -1,57 +1,95 @@
 """Tests for h5 endpoint."""
 
+import earthaccess
 import pytest
+
 import h5coro
 from h5coro import s3driver, webdriver
-import earthaccess
 
 auth = earthaccess.login()
 credentials = auth.get_s3_credentials(daac="NSIDC")
 
 ATL06_HTTP_URL = "https://data.nsidc.earthdatacloud.nasa.gov/nsidc-cumulus-prod-protected/ATLAS/ATL06/006/2018/10/14/ATL06_20181014001049_02350102_006_02.h5"
-ATL06_DATASET = 'gt1r/land_ice_segments/h_li'
+ATL06_DATASET = "gt1r/land_ice_segments/h_li"
 
 ATL03_S3_OBJECT = "nsidc-cumulus-prod-protected/ATLAS/ATL03/006/2018/10/17/ATL03_20181017222812_02950102_006_02.h5"
-ATL03_ATTRIBUTE = 'gt2l/heights/h_ph/units'
-ATL03_DATASET = 'gt2l/heights/h_ph'
-ATL03_GROUP = 'gt2l/heights'
+ATL03_PUBLIC_BUCKET = "its-live-data/cloud-experiments/h5cloud/atl03/average/original/ATL03_20191225111315_13680501_006_01.h5"
+
+ATL03_ATTRIBUTE = "gt2l/heights/h_ph/units"
+ATL03_DATASET = "gt2l/heights/h_ph"
+ATL03_GROUP = "gt2l/heights"
+
 
 @pytest.mark.region
 class TestIcesat2:
-
     def test_http_driver(self):
-        edl_token = auth.token["access_token"] 
-        h5obj = h5coro.H5Coro(ATL06_HTTP_URL, webdriver.HTTPDriver, credentials=edl_token)
+        edl_token = auth.token["access_token"]
+        h5obj = h5coro.H5Coro(
+            ATL06_HTTP_URL, webdriver.HTTPDriver, credentials=edl_token
+        )
         promise = h5obj.readDatasets([ATL06_DATASET], block=True)
         assert len(promise[ATL06_DATASET]) == 3880
 
     def test_s3driver(self):
-        h5obj = h5coro.H5Coro(ATL03_S3_OBJECT, s3driver.S3Driver, credentials=credentials)
-        promise = h5obj.readDatasets([ATL03_DATASET], block=True, enableAttributes=False)
+        h5obj = h5coro.H5Coro(
+            ATL03_S3_OBJECT, s3driver.S3Driver, credentials=credentials
+        )
+        promise = h5obj.readDatasets(
+            [ATL03_DATASET], block=True, enableAttributes=False
+        )
         assert len(promise[ATL03_DATASET]) == 20622551
         assert abs(promise[ATL03_DATASET][0] - 2553.04) < 0.0001
 
+    def test_s3driver_public_bucket(self):
+        h5obj = h5coro.H5Coro(
+            ATL03_PUBLIC_BUCKET, s3driver.S3Driver, credentials={"annon": True}
+        )
+        promise = h5obj.readDatasets(
+            [ATL03_DATASET], block=True, enableAttributes=False
+        )
+        assert len(promise[ATL03_DATASET]) == 218644
+        assert abs(promise[ATL03_DATASET][0] - 119.13542) < 0.0001
+
     @pytest.mark.parametrize("attr", [True, False])
     @pytest.mark.parametrize("early", [True, False])
-    @pytest.mark.parametrize("dataset", [ATL03_DATASET, "/"+ATL03_DATASET])
+    @pytest.mark.parametrize("dataset", [ATL03_DATASET, "/" + ATL03_DATASET])
     def test_read_datasets(self, attr, early, dataset):
-        h5obj = h5coro.H5Coro(ATL03_S3_OBJECT, s3driver.S3Driver, credentials=credentials)
-        promise = h5obj.readDatasets([dataset], block=True, earlyExit=early, enableAttributes=attr)
-        expected = [2693.3584, 2595.145, 2590.695, 2606.2778, 2492.0835, 2213.4001, 2059.4768, 2031.4877, 2627.5674, 2478.4314]
+        h5obj = h5coro.H5Coro(
+            ATL03_S3_OBJECT, s3driver.S3Driver, credentials=credentials
+        )
+        promise = h5obj.readDatasets(
+            [dataset], block=True, earlyExit=early, enableAttributes=attr
+        )
+        expected = [
+            2693.3584,
+            2595.145,
+            2590.695,
+            2606.2778,
+            2492.0835,
+            2213.4001,
+            2059.4768,
+            2031.4877,
+            2627.5674,
+            2478.4314,
+        ]
         for i in range(len(expected)):
             assert abs(promise[ATL03_DATASET][100:110][i] - expected[i]) < 0.001
 
     def test_inspect_variable(self):
-        h5obj = h5coro.H5Coro(ATL03_S3_OBJECT, s3driver.S3Driver, credentials=credentials)
+        h5obj = h5coro.H5Coro(
+            ATL03_S3_OBJECT, s3driver.S3Driver, credentials=credentials
+        )
         links, attributes, metadata = h5obj.inspectPath(ATL03_DATASET, w_attr=True)
         assert metadata.dimensions[0] == 20622551
-        assert attributes['units'] == 'meters'
+        assert attributes["units"] == "meters"
 
     def test_list_group(self):
-        h5obj = h5coro.H5Coro(ATL03_S3_OBJECT, s3driver.S3Driver, credentials=credentials)
+        h5obj = h5coro.H5Coro(
+            ATL03_S3_OBJECT, s3driver.S3Driver, credentials=credentials
+        )
         variables, attributes, groups = h5obj.list(ATL03_GROUP, w_attr=True)
         assert len(variables.keys()) == 13
-        assert 'dist_ph_along' in variables
-        assert 'data_rate' in attributes
+        assert "dist_ph_along" in variables
+        assert "data_rate" in attributes
         assert type(attributes["data_rate"]) == str
         assert variables["weight_ph"]["valid_max"][0] == 255


### PR DESCRIPTION
Hi JP, 

This PR adds non-signed requests to S3 when we pass `credentials={"annon": True}` and this makes H5Coro work with data in public buckets, we are doing some testing and wanted to use data staged in the ITS_LIVE public bucket.

